### PR TITLE
Split up tty dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Arcanus Changelog
 
+## master (unreleased)
+
+* Split up `tty` dependencies (`tty` has a very restrictive gemspec)
+
 ## 1.2.0
 
   Update `tty` dependency to v0.3+

--- a/arcanus.gemspec
+++ b/arcanus.gemspec
@@ -21,5 +21,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
 
   s.add_dependency 'diffy', '~> 3.1'
-  s.add_dependency 'tty', '~> 0.3'
+  s.add_dependency 'pastel', '~> 0.7'
+  s.add_dependency 'tty-prompt', '~> 0.16'
+  s.add_dependency 'tty-spinner', '~> 0.8'
+  s.add_dependency 'tty-table', '~> 0.10'
 end

--- a/lib/arcanus/ui.rb
+++ b/lib/arcanus/ui.rb
@@ -1,5 +1,8 @@
 require 'forwardable'
-require 'tty'
+require 'pastel'
+require 'tty-prompt'
+require 'tty-spinner'
+require 'tty-table'
 
 module Arcanus
   # Manages all interaction with the user.


### PR DESCRIPTION
Because tty has a very restrictive gemspec, dependency resolution
becomes difficult when installing arcanus alongside another gem which
depends on tty components. Splitting up the components and allowing for
newer versions of those components should help mitigate this issue.