### PR TITLE
Delegate y/n question to tty-prompt

### DIFF
--- a/lib/arcanus/command/edit.rb
+++ b/lib/arcanus/command/edit.rb
@@ -59,11 +59,7 @@ module Arcanus::Command
         rescue => ex
           ui.error "Error occurred while modifying the chest: #{ex.message}"
 
-          unless ui.ask('Do you want to try editing the same file again? (y/n)')
-                   .argument(:required)
-                   .default('y')
-                   .modify('downcase')
-                   .read_string == 'y'
+          unless ui.yes?('Do you want to try editing the same file again?')
             break
           end
         end

--- a/lib/arcanus/ui.rb
+++ b/lib/arcanus/ui.rb
@@ -6,7 +6,7 @@ module Arcanus
   class UI
     extend Forwardable
 
-    def_delegators :@prompt, :ask, :confirm
+    def_delegators :@prompt, :ask, :confirm, :yes?
 
     # Creates a {UI} that mediates between the given input/output streams.
     #


### PR DESCRIPTION
There seems to be an issue with the `ask` setup in edit.rb. tty-prompt
exposes a `yes?` method for displaying a query asking for a boolean
input, and delegating to it appears to fix the issue.

Fixes #4 