### PR TITLE
Update rubocop version to avoid an open CVE security issue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,7 @@ Style/Documentation:
     - 'lib/arcanus/command/**/*.rb'
     - 'spec/**/*'
 
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: leading
 
 Style/Encoding:
@@ -87,7 +87,7 @@ Style/SingleLineBlockParams:
 Style/SpecialGlobalVars:
   Enabled: false
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Enabled: false
 
 Style/NumericPredicate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master (unreleased)
 
 * Split up `tty` dependencies (`tty` has a very restrictive gemspec)
+* Delegate y/n question to tty-prompt
+* Update rubocop version to avoid CVE-2017-8418
+* Fix the rubocop config and ignore a couple cops
 
 ## 1.2.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'overcommit', '0.39.1'
-gem 'rubocop', '0.45.0'
+gem 'rubocop', '0.49.0'
 gem 'travis', '~> 1.7'

--- a/lib/arcanus/chest.rb
+++ b/lib/arcanus/chest.rb
@@ -210,7 +210,7 @@ module Arcanus
               "expected #{signature} but got #{actual_signature}"
       end
 
-      Marshal.load(dumped_value)
+      Marshal.load(dumped_value) # rubocop:disable MarshalLoad
     end
 
     # Helper class for returning contents nested hashes, exposing helpers to

--- a/lib/arcanus/command/help.rb
+++ b/lib/arcanus/command/help.rb
@@ -23,7 +23,7 @@ module Arcanus::Command
 
     def command_classes
       command_files =
-        Dir[File.join(File.dirname(__FILE__), '*.rb')]
+        Dir[File.join(File.dirname(__FILE__), '*.rb')] # rubocop:disable InverseMethods
         .select { |path| File.basename(path, '.rb') != 'base' }
 
       command_files.map do |file|


### PR DESCRIPTION
See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418 for
more details.