### PR TITLE
Don't save unprotected key file when exporting and providing ARCANUS_…

### DIFF
--- a/lib/arcanus/command/export.rb
+++ b/lib/arcanus/command/export.rb
@@ -9,9 +9,13 @@ module Arcanus::Command
                 'consumption by other programs'
 
     def execute
-      ensure_key_unlocked
+      if ENV.key?('ARCANUS_PASSWORD')
+        key = Arcanus::Key.from_protected_file(repo.locked_key_path, ENV['ARCANUS_PASSWORD'])
+      else
+        ensure_key_unlocked
+        key = Arcanus::Key.from_file(repo.unlocked_key_path)
+      end
 
-      key = Arcanus::Key.from_file(repo.unlocked_key_path)
       chest = Arcanus::Chest.new(key: key, chest_file_path: repo.chest_file_path)
 
       env_vars = extract_env_vars(chest.to_hash)


### PR DESCRIPTION
…PASSWORD

When providing the password via ARCANUS_PASSWORD, don't save the unprotected
key file when exporting env vars. This is useful in CI environments.